### PR TITLE
Fix an issue with backlink implementation, add more and cleanup navigation tests. Add radiogroup wrapper story

### DIFF
--- a/mineral-collection-site/src/app/_shared/components/formComponents/radioGroupWrapper/radioGroupWrapper.stories.tsx
+++ b/mineral-collection-site/src/app/_shared/components/formComponents/radioGroupWrapper/radioGroupWrapper.stories.tsx
@@ -1,20 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
-import { userEvent, within } from '@storybook/test';
-
 import RadioGroupWrapper, { RadioGroupWrapperProps, RadioWrapper } from './radioGroupWrapper';
-
-{
-  /* <RadioGroupWrapper
-          name='sortBy'
-          value={sortBy}
-          label='Sort By'
-          onChange={updateSortBy}>
-          <RadioWrapper value='numericId'>Id</RadioWrapper>
-          <RadioWrapper value='name'>Name</RadioWrapper>
-        </RadioGroupWrapper> */
-}
 
 const meta = {
   title: 'FormComponents/RadioGroupWrapper',

--- a/mineral-collection-site/src/app/_shared/components/formComponents/radioGroupWrapper/radioGroupWrapper.stories.tsx
+++ b/mineral-collection-site/src/app/_shared/components/formComponents/radioGroupWrapper/radioGroupWrapper.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+
+import { userEvent, within } from '@storybook/test';
+
+import RadioGroupWrapper, { RadioGroupWrapperProps, RadioWrapper } from './radioGroupWrapper';
+
+{
+  /* <RadioGroupWrapper
+          name='sortBy'
+          value={sortBy}
+          label='Sort By'
+          onChange={updateSortBy}>
+          <RadioWrapper value='numericId'>Id</RadioWrapper>
+          <RadioWrapper value='name'>Name</RadioWrapper>
+        </RadioGroupWrapper> */
+}
+
+const meta = {
+  title: 'FormComponents/RadioGroupWrapper',
+  component: RadioGroupWrapper,
+  subcomponents: { RadioWrapper },
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof RadioGroupWrapper>;
+
+export default meta;
+type Story = StoryObj<typeof RadioGroupWrapper>;
+
+interface RadioGroupWithHooksProps extends RadioGroupWrapperProps {
+  startValue?: string;
+}
+
+function RadioGroupWithHooks({ ...props }: RadioGroupWithHooksProps) {
+  const [value, setValue] = useState(props.startValue || '');
+  return (
+    <RadioGroupWrapper {...props} value={value} onChange={setValue}>
+      {props.children}
+    </RadioGroupWrapper>
+  );
+}
+
+export const Default: Story = {
+  args: {
+    label: 'Radio Group',
+    name: 'radioGroup',
+  },
+  render: (args) => (
+    <RadioGroupWithHooks label={args.label} name={args.name}>
+      <RadioWrapper value='1'>Option 1</RadioWrapper>
+      <RadioWrapper value='2'>Option 2</RadioWrapper>
+      <RadioWrapper value='3'>Option 3</RadioWrapper>
+    </RadioGroupWithHooks>
+  ),
+};
+
+export const Selected: Story = {
+  render: () => (
+    <RadioGroupWithHooks label='Radio Group' name='radioGroup' startValue={'1'}>
+      <RadioWrapper value='1'>Option 1</RadioWrapper>
+      <RadioWrapper value='2'>Option 2</RadioWrapper>
+      <RadioWrapper value='3'>Option 3</RadioWrapper>
+    </RadioGroupWithHooks>
+  ),
+};

--- a/mineral-collection-site/src/app/_shared/components/formComponents/radioGroupWrapper/radioGroupWrapper.tsx
+++ b/mineral-collection-site/src/app/_shared/components/formComponents/radioGroupWrapper/radioGroupWrapper.tsx
@@ -4,7 +4,8 @@ import { FieldError, Label, Radio, RadioGroup, Text } from 'react-aria-component
 
 import styles from './radioGroupWrapper.module.css';
 
-interface RadioGroupWrapperProps extends Omit<RadioGroupProps, 'children'> {
+export interface RadioGroupWrapperProps
+  extends Omit<RadioGroupProps, 'children'> {
   children?: React.ReactNode;
   label?: string;
   description?: string;

--- a/mineral-collection-site/src/app/_shared/services/navigationHelpersService.ts
+++ b/mineral-collection-site/src/app/_shared/services/navigationHelpersService.ts
@@ -13,7 +13,11 @@ export async function getBackLink(
   const referrer = headersList.get('referer');
   const baseUrl = process.env.NEXT_PUBLIC_URL;
 
-  if (!referrer || !baseUrl || referrer.match(`/${currentSlug}`)) {
+  if (
+    !referrer ||
+    !baseUrl ||
+    referrer.match(new RegExp(`//${currentSlug}$`))
+  ) {
     return { referrerPath: href, referrerTitle: title };
   }
   const referrerPath = referrer.replace(baseUrl, '');

--- a/mineral-collection-site/tests/navigation.spec.ts
+++ b/mineral-collection-site/tests/navigation.spec.ts
@@ -86,96 +86,172 @@ test.describe('Header Navigation', () => {
 });
 test.describe('Navigate to Individual Pages', () => {
   test('Navigate to Specific Mineral', async ({ page }) => {
-    await page
-      .getByRole('main')
-      .getByRole('link', { name: 'Minerals' })
-      .click();
-    await page.getByRole('searchbox', { name: 'Search' }).click();
-    await page.getByRole('searchbox', { name: 'Search' }).fill('Amethyst');
-    await page.waitForURL('**/minerals?search=Amethyst');
-    await page.getByRole('link', { name: 'Amethyst', exact: true }).click();
-    await page.waitForURL('**/minerals/amethyst');
-    await expect(
-      page.getByRole('heading', { name: 'Amethyst', exact: true })
-    ).toBeVisible();
+    const mineralTitle = /^Amethyst$/;
+    await test.step('Navigate to Minerals Page', async () => {
+      await page
+        .getByRole('main')
+        .getByRole('link', { name: 'Minerals' })
+        .click();
+    });
+    await test.step('Search for Mineral', async () => {
+      await page.getByRole('searchbox', { name: 'Search' }).click();
+      await page.getByRole('searchbox', { name: 'Search' }).fill('Amethyst');
+      await page.waitForURL('**/minerals?search=Amethyst');
+    });
+    await test.step('Click on Mineral Link', async () => {
+      await page.getByRole('link', { name: mineralTitle, exact: true }).click();
+    });
+    await test.step('Verify Mineral Page', async () => {
+      await expect(page.locator('h1', { hasText: mineralTitle })).toBeVisible();
+    });
   });
 
   test('Navigate to Specific Rock', async ({ page }) => {
-    await page.getByRole('main').getByRole('link', { name: 'Rocks' }).click();
-    await page.getByRole('searchbox', { name: 'Search' }).click();
-    await page.getByRole('searchbox', { name: 'Search' }).fill('Basalt');
-    await page.waitForURL('**/rocks?search=Basalt');
-    await page.getByRole('link', { name: 'Basalt', exact: true }).click();
-    await page.waitForURL('**/rocks/basalt');
-    await expect(
-      page.getByRole('heading', { name: 'Basalt', exact: true })
-    ).toBeVisible();
+    const rockTitle = /^Basalt$/;
+    await test.step('Navigate to Rocks Page', async () => {
+      await page.getByRole('main').getByRole('link', { name: 'Rocks' }).click();
+    });
+    await test.step('Search for Rock', async () => {
+      await page.getByRole('searchbox', { name: 'Search' }).click();
+      await page.getByRole('searchbox', { name: 'Search' }).fill('Basalt');
+      await page.waitForURL('**/rocks?search=Basalt');
+    });
+    await test.step('Click on Rock Link', async () => {
+      await page.getByRole('link', { name: rockTitle, exact: true }).click();
+    });
+    await test.step('Verify Rock Page', async () => {
+      await expect(page.locator('h1', { hasText: rockTitle })).toBeVisible();
+    });
   });
 
   test('Navigate to Specific Specimen', async ({ page }) => {
-    await page
-      .getByRole('main')
-      .getByRole('link', { name: 'Specimens', exact: true })
-      .click();
-    await page.getByRole('searchbox', { name: 'Search' }).click();
-    await page.getByRole('searchbox', { name: 'Search' }).fill('Baryte');
-    await page.waitForURL('**/specimens?search=Baryte');
-    await page.getByRole('link', { name: 'Baryte - #715' }).click();
-    await page.waitForURL('**/specimens/baryte-715');
-    await expect(
-      page.getByRole('heading', { name: 'Baryte - #715' })
-    ).toBeVisible();
+    const specimenTitle = /^Baryte - #715$/;
+    await test.step('Navigate to Specimens Page', async () => {
+      await page
+        .getByRole('main')
+        .getByRole('link', { name: 'Specimens', exact: true })
+        .click();
+    });
+    await test.step('Search for Specimen', async () => {
+      await page.getByRole('searchbox', { name: 'Search' }).click();
+      await page.getByRole('searchbox', { name: 'Search' }).fill('715');
+      await page.waitForURL('**/specimens?search=715');
+    });
+    await test.step('Click on Specimen Link', async () => {
+      await page.getByRole('link', { name: specimenTitle }).click();
+    });
+    await test.step('Verify Specimen Page', async () => {
+      await expect(
+        page.locator('h1', { hasText: specimenTitle })
+      ).toBeVisible();
+    });
   });
 });
 
 test.describe('Navigate Through Chained Pages', () => {
   test('Navigate Between Multiple Pages with BackLink', async ({ page }) => {
-    await page
-      .getByRole('main')
-      .getByRole('link', { name: 'Minerals' })
-      .click();
-    await page.getByRole('searchbox', { name: 'Search' }).click();
-    await page.getByRole('searchbox', { name: 'Search' }).fill('Agate');
-    await page.waitForURL('**/minerals?search=Agate');
-    await page.getByRole('link', { name: 'Agate', exact: true }).click();
-    await page.waitForURL('**/minerals/agate');
-    await expect(
-      page.getByRole('heading', { name: 'Agate', exact: true })
-    ).toBeVisible();
-    await expect(
-      page.getByRole('link', { name: '← Back to Minerals' })
-    ).toBeVisible();
-    await page.getByRole('link', { name: 'Quartz' }).click();
-    await page.waitForURL('**/minerals/quartz');
-    await expect(
-      page.getByRole('heading', { name: 'Quartz', exact: true })
-    ).toBeVisible();
-    await expect(
-      page.getByRole('link', { name: '← Back to Agate' })
-    ).toBeVisible();
-    await page.getByRole('link', { name: '← Back to Agate' }).click();
-    await page.waitForURL('**/minerals/agate');
-    await expect(
-      page.getByRole('heading', { name: 'Agate', exact: true })
-    ).toBeVisible();
-    await expect(
-      page.getByRole('link', { name: '← Back to Quartz' })
-    ).toBeVisible();
-    await page
-      .getByRole('link', { name: 'Agate - Blue Lace', exact: true })
-      .click();
+    const agateTitle = /^Agate$/;
+    const quartzTitle = /^Quartz$/;
+    const blueLaceAgateTitle = /^Agate - Blue Lace$/;
+    const agateBackLink = /^← Back to Agate$/;
+    const quartzBackLink = /^← Back to Quartz$/;
+    const blueLaceAgateBackLink = /^← Back to Agate Blue Lace$/;
+    await test.step('Navigate to Mineral Page and search for Agate', async () => {
+      await page
+        .getByRole('main')
+        .getByRole('link', { name: 'Minerals' })
+        .click();
+      await page.getByRole('searchbox', { name: 'Search' }).click();
+      await page.getByRole('searchbox', { name: 'Search' }).fill('Agate');
+      await page.getByRole('link', { name: agateTitle, exact: true }).click();
+    });
+    await test.step('Load Agate Page', async () => {
+      await expect(page.locator('h1', { hasText: agateTitle })).toBeVisible();
+      await expect(
+        page.getByRole('link', { name: '← Back to Minerals' })
+      ).toBeVisible();
+    });
+    await test.step('Navigate to Quartz Page', async () => {
+      await page.getByRole('link', { name: quartzTitle }).click();
+      await expect(page.locator('h1', { hasText: quartzTitle })).toBeVisible();
+      await expect(
+        page.getByRole('link', { name: agateBackLink })
+      ).toBeVisible();
+    });
+    await test.step('Return to Agate Page', async () => {
+      await page.getByRole('link', { name: agateBackLink }).click();
+      await expect(page.locator('h1', { hasText: agateTitle })).toBeVisible();
+      await expect(
+        page.getByRole('link', { name: quartzBackLink })
+      ).toBeVisible();
+    });
+    await test.step('Navigate to Blue Lace Agate Page', async () => {
+      await page
+        .getByRole('link', { name: blueLaceAgateTitle, exact: true })
+        .click();
+      await expect(
+        page.locator('h1', { hasText: blueLaceAgateTitle })
+      ).toBeVisible();
+      await expect(
+        page.getByRole('link', { name: agateBackLink })
+      ).toBeVisible();
+    });
+    await test.step('Return to Agate Page', async () => {
+      await page.getByRole('link', { name: agateBackLink }).click();
+      await expect(page.locator('h1', { hasText: agateTitle })).toBeVisible();
+      await expect(
+        page.getByRole('link', { name: blueLaceAgateBackLink })
+      ).toBeVisible();
+    });
+  });
 
-    await page.waitForURL('**/minerals/agate-blue-lace');
-    await expect(
-      page.getByRole('heading', { name: 'Agate - Blue Lace' })
-    ).toBeVisible();
-    await expect(
-      page.getByRole('link', { name: '← Back to Agate' })
-    ).toBeVisible();
-    await page.getByRole('link', { name: '← Back to Agate' }).click();
-    await page.waitForURL('**/minerals/agate');
-    await expect(
-      page.getByRole('heading', { name: 'Agate', exact: true })
-    ).toBeVisible();
+  test('Backlink Between Mineral and Specimen', async ({ page }) => {
+    const specimenHeading = /^Conichalcite - #714$/;
+    const specimenBackLink = /^← Back to Conichalcite 714$/;
+    const mineralHeading = /^Conichalcite$/;
+    const mineralBackLink = /^← Back to Conichalcite$/;
+
+    await test.step('Load Specimens Page and search for specimen', async () => {
+      await page.goto('./specimens');
+      await page.getByRole('searchbox', { name: 'Search' }).click();
+      await page.getByRole('searchbox', { name: 'Search' }).fill('714');
+      await page.getByRole('link', { name: specimenHeading }).click();
+    });
+    await test.step('Load Specimen Page for Conichalcite 714', async () => {
+      await expect(
+        page.getByRole('link', { name: '← Back to Specimens' })
+      ).toBeVisible();
+      await expect(
+        page.locator('h1', { hasText: specimenHeading })
+      ).toBeVisible();
+    });
+    await test.step('Navigate to Conichalcite Mineral Page', async () => {
+      await page
+        .locator('dl')
+        .filter({ hasText: 'Classifications:' })
+        .getByRole('link')
+        .click();
+      await expect(
+        page.getByRole('link', { name: specimenBackLink })
+      ).toBeVisible();
+      await expect(
+        page.locator('h1', { hasText: mineralHeading })
+      ).toBeVisible();
+    });
+    await test.step('Navigate back to Specimen Page for Conichalcite 714 by backlink', async () => {
+      await page.getByRole('link', { name: specimenBackLink }).click();
+      await expect(
+        page.getByRole('link', { name: mineralBackLink, exact: true })
+      ).toBeVisible();
+      await expect(
+        page.locator('h1', { hasText: specimenHeading })
+      ).toBeVisible();
+    });
+    await test.step('Navigate to Conichalcite Mineral Page by backlink', async () => {
+      await page.getByRole('link', { name: mineralBackLink }).click();
+      await expect(
+        page.locator('h1', { hasText: mineralHeading })
+      ).toBeVisible();
+    });
   });
 });


### PR DESCRIPTION
This pull request introduces several updates, including enhancements to the `RadioGroupWrapper` component, improvements to navigation handling, and refactoring of test cases for better readability and maintainability. Below are the most important changes grouped by theme:

### Component Enhancements:
* Added a new Storybook file for `RadioGroupWrapper` to demonstrate its usage with examples, including default and pre-selected states. This includes a `RadioGroupWithHooks` wrapper to manage state. (`radioGroupWrapper.stories.tsx`)
* Exported `RadioGroupWrapperProps` from the `RadioGroupWrapper` component for external use. (`radioGroupWrapper.tsx`)

### Navigation Logic:
* Updated the `getBackLink` function to use a more specific regular expression for matching URLs, ensuring more accurate backlink generation. (`navigationHelpersService.ts`)

### Test Refactoring:
* Refactored navigation tests to use `test.step` for better structure and readability, breaking down actions such as navigating, searching, and verifying into distinct steps. This applies to tests for minerals, rocks, specimens, and chained navigation. (`navigation.spec.ts`)